### PR TITLE
feat: Remove role selection from signup and set default role to student

### DIFF
--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -24,10 +24,11 @@ export async function POST(request: NextRequest) {
       return validation.error
     }
     
-    const { name, email, password, role } = validation.data
+    const { name, email, password } = validation.data
 
     // Role is always 'student' for new signups
     // Admins are created directly in the database
+    const role = 'student'
 
     // Check if user already exists
     const { data: existingUser } = await supabase

--- a/components/auth-modal.tsx
+++ b/components/auth-modal.tsx
@@ -9,7 +9,6 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Loader2 } from 'lucide-react'
 
@@ -34,8 +33,7 @@ export default function AuthModal({ isOpen, onClose, defaultTab = 'signin' }: Au
     email: '',
     password: '',
     confirmPassword: '',
-    name: '',
-    role: 'student' as 'admin' | 'student'
+    name: ''
   })
 
   // Sign in form state
@@ -60,8 +58,7 @@ export default function AuthModal({ isOpen, onClose, defaultTab = 'signin' }: Au
         email: '',
         password: '',
         confirmPassword: '',
-        name: '',
-        role: 'student'
+        name: ''
       })
       setSignInData({
         email: '',
@@ -144,7 +141,6 @@ export default function AuthModal({ isOpen, onClose, defaultTab = 'signin' }: Au
           name: signUpData.name,
           email: signUpData.email,
           password: signUpData.password,
-          role: signUpData.role,
         }),
       })
 
@@ -159,8 +155,7 @@ export default function AuthModal({ isOpen, onClose, defaultTab = 'signin' }: Au
         email: '',
         password: '',
         confirmPassword: '',
-        name: '',
-        role: 'student'
+        name: ''
       })
       setActiveTab('signin')
     } catch (error: any) {
@@ -387,18 +382,6 @@ export default function AuthModal({ isOpen, onClose, defaultTab = 'signin' }: Au
                       )}
                     </div>
 
-                    <div className="space-y-2">
-                      <Label htmlFor="signup-role">Role</Label>
-                      <Select value={signUpData.role} onValueChange={(value: 'admin' | 'student') => setSignUpData({ ...signUpData, role: value })}>
-                        <SelectTrigger>
-                          <SelectValue placeholder="Select your role" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="student">Student</SelectItem>
-                          <SelectItem value="admin">Admin</SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </div>
 
                     <div className="space-y-2">
                       <Label htmlFor="signup-password">Password</Label>

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -11,8 +11,7 @@ export const uuidSchema = z.string().uuid('Invalid ID format')
 export const createUserSchema = z.object({
   email: emailSchema,
   password: passwordSchema,
-  name: nameSchema,
-  role: z.enum(['admin', 'student']).default('student')
+  name: nameSchema
 })
 
 export const updateUserSchema = z.object({


### PR DESCRIPTION
- Remove role selection UI from auth modal signup form
- Update signup API to always set role as 'student'
- Update validation schema to remove role requirement
- Remove role from signup form state and validation
- Clean up unused Select component imports
- All new accounts will automatically be created as students
- Admins can still be created through admin panel if needed