### PR TITLE
Fix reset password email links

### DIFF
--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -541,8 +541,8 @@ export const notificationService = NotificationService.getInstance()
 export async function sendForgotPasswordEmail(email: string, userName: string, resetToken: string) {
   // Vercel automatically sets NEXTAUTH_URL, fallback to localhost for development
   const baseUrl = process.env.NEXTAUTH_URL || 'http://localhost:3000'
-  const basePath = process.env.BASE_PATH || '/startup-tycoon'
-  const resetLink = `${baseUrl}${basePath}/reset-password?token=${resetToken}`
+  // Remove basePath since we're not using subdirectory deployment anymore
+  const resetLink = `${baseUrl}/reset-password?token=${resetToken}`
   
   return await notificationService.sendEmail({
     to: email,


### PR DESCRIPTION
- Remove BASE_PATH from reset password email generation
- Reset password links now work correctly without subdirectory path
- Fixes 'Unexpected token <' error on reset password page