### PR TITLE
improve: Use VERCEL_URL instead of NEXT_PUBLIC_VERCEL_URL

### DIFF
--- a/lib/notifications.ts
+++ b/lib/notifications.ts
@@ -540,9 +540,10 @@ export const notificationService = NotificationService.getInstance()
 // Helper functions for common notification scenarios
 export async function sendForgotPasswordEmail(email: string, userName: string, resetToken: string) {
   // Use Vercel URL for production, fallback to NEXTAUTH_URL for development
-  const baseUrl = process.env.NEXT_PUBLIC_VERCEL_URL 
-    ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}` 
-    : process.env.NEXTAUTH_URL || 'http://localhost:3000'
+  const baseUrl =
+    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : null) ||
+    process.env.NEXTAUTH_URL ||
+    'http://localhost:3000';
   const resetLink = `${baseUrl}/reset-password?token=${resetToken}`
   
   return await notificationService.sendEmail({
@@ -596,9 +597,10 @@ export async function sendAssignmentStartedNotification(
     minute: '2-digit'
   })
   
-  const baseUrl = process.env.NEXT_PUBLIC_VERCEL_URL 
-    ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}` 
-    : process.env.NEXTAUTH_URL || 'http://localhost:3000'
+  const baseUrl =
+    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : null) ||
+    process.env.NEXTAUTH_URL ||
+    'http://localhost:3000';
   const assignmentLink = `${baseUrl}/courses/${courseId}/assignments/${assignmentId}`
   
   return await notificationService.sendEmail({
@@ -666,9 +668,10 @@ export async function sendEvaluationStartedNotification(
       })
     : 'TBD'
   
-  const baseUrl = process.env.NEXT_PUBLIC_VERCEL_URL 
-    ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}` 
-    : process.env.NEXTAUTH_URL || 'http://localhost:3000'
+  const baseUrl =
+    (process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : null) ||
+    process.env.NEXTAUTH_URL ||
+    'http://localhost:3000';
   const evaluationLink = `${baseUrl}/courses/${courseId}/evaluations/${assignmentId}`
   
   return await notificationService.sendEmail({


### PR DESCRIPTION
- Use process.env.VERCEL_URL (automatically set by Vercel)
- Cleaner null coalescing pattern with || operator
- No need for NEXT_PUBLIC_ prefix for server-side usage
- More efficient and follows Vercel best practices

This is the recommended approach for Vercel deployments.